### PR TITLE
ZFile support batch compress

### DIFF
--- a/src/overlaybd/fs/zfile/compressor.cpp
+++ b/src/overlaybd/fs/zfile/compressor.cpp
@@ -18,6 +18,13 @@
 #include "lz4/lz4.h"
 #include "../../alog.h"
 #include <memory>
+#include <vector>
+
+// #ifdef ENABLE_QAT
+#include "lz4/lz4-qat.h"
+// #endif
+
+using namespace std;
 
 namespace ZFile {
 
@@ -25,41 +32,141 @@ class Compressor_lz4 : public ICompressor {
 public:
     uint32_t max_dst_size = 0;
     uint32_t src_blk_size = 0;
+    bool qat_enable = false;
+
+    LZ4_qat_param *pQat = nullptr;
+
+    vector<unsigned char *> raw_data;
+    vector<unsigned char *> compressed_data;
+
+    const int DEFAULT_N_BATCH = 256;
+
+    ~Compressor_lz4() {
+        // missing qat_uninit() ?
+        if (pQat) {
+            delete pQat;
+        }
+    }
+
+    bool check_qat() {
+
+#ifdef ENABLE_QAT
+        struct pci_access *pacc;
+        struct pci_dev *dev;
+        pacc = pci_alloc();
+        pci_init(pacc);
+        pci_scan_bus(pacc);
+        for (dev = pacc->devices; dev; dev = dev->next) {
+            pci_fill_info(dev, PCI_FILL_IDENT | PCI_FILL_BASES);
+            if (dev->vendor_id == QAT_VENDOR_ID && dev->device_id == QAT_DEVICE_ID) {
+                pci_cleanup(pacc);
+                return true;
+            }
+        }
+        pci_cleanup(pacc);
+        
+        return false;
+#endif
+        return false;
+    }
 
     int init(const CompressArgs *args) {
         auto opt = &args->opt;
         if (opt == nullptr) {
             LOG_ERROR_RETURN(EINVAL, -1, "CompressOptions* is nullptr.");
-        };
+        }
         if (opt->type != CompressOptions::LZ4) {
             LOG_ERROR_RETURN(EINVAL, -1,
                              "Compression type invalid. (expected: CompressionOptions::LZ4)");
         }
         src_blk_size = opt->block_size;
         max_dst_size = LZ4_compressBound(src_blk_size);
+        if (check_qat()) {
+            pQat = new LZ4_qat_param();
+            qat_init(pQat);
+            qat_enable = true;
+        }
+        LOG_INFO("create batch buffer, size: `", nbatch());
+        raw_data.resize(nbatch());
+        compressed_data.resize(nbatch());
         return 0;
     }
 
     int compress(const unsigned char *src, size_t src_len, unsigned char *dst,
                  size_t dst_len) override {
-        if (dst_len < max_dst_size) {
+
+        size_t dst_chunk_len;
+        if (compress_batch(src, &src_len, dst, dst_len, &dst_chunk_len, 1) != 0) {
+            LOG_ERRNO_RETURN(0, -1, "compress data failed.");
+        }
+        return dst_chunk_len; // return decompressed size for single block.
+    }
+
+    int nbatch() override {
+        // return DEFAULT_N_BATCH;
+        return (qat_enable ? DEFAULT_N_BATCH : 1);
+    }
+
+    int compress_batch(const unsigned char *src, size_t *src_chunk_len, unsigned char *dst,
+                       size_t dst_buffer_capacity, size_t *dst_chunk_len, size_t n) override {
+
+        if (dst_buffer_capacity / n < max_dst_size) {
             LOG_ERROR_RETURN(ENOBUFS, -1, "dst_len should be greater than `", max_dst_size - 1);
         }
-
-        auto ret = LZ4_compress_default((const char *)src, (char *)dst, src_len, dst_len);
-        if (ret < 0) {
-            LOG_ERROR_RETURN(EFAULT, -1, "LZ4 compress data failed. (retcode: `).", ret);
+        off_t src_offset = 0, dst_offset = 0;
+        int ret = 0;
+        for (int i = 0; i < n; i++) {
+            raw_data[i] = ((unsigned char *)src + src_offset);
+            compressed_data[i] = ((unsigned char *)dst + dst_offset);
+            src_offset += src_chunk_len[i];
+            dst_offset += dst_buffer_capacity / n;
         }
-        if (ret == 0) {
-            LOG_ERROR_RETURN(
-                EFAULT, -1,
-                "Compression worked, but was stopped because the *dst couldn't hold all the information.");
+#ifdef ENABLE_QAT
+        if (qat_enable) {
+            // confirm this?
+            ret = LZ4_compress_qat(pQat, raw_data, steplist, compressed_data, dst_chunk_len, cur);
+            if (ret < 0) {
+                LOG_ERROR_RETURN(EFAULT, -1, "LZ4 compress data failed. (retcode: `).", ret);
+            }
+            return ret;
         }
-        return ret;
+#endif
+        for (ssize_t i = 0; i < n; i++) {
+            ret = LZ4_compress_default((const char *)raw_data[i], (char *)compressed_data[i],
+                                       src_chunk_len[i], dst_buffer_capacity / n);
+           
+            dst_chunk_len[i] = ret;
+            if (ret < 0) {
+                LOG_ERROR_RETURN(EFAULT, -1, "LZ4 compress data failed. (retcode: `).", ret);
+            }
+            if (ret == 0) {
+                LOG_ERROR_RETURN(EFAULT, -1,
+                    "Compression worked, but was stopped because the *dst couldn't hold all the information.");
+            }
+        }
+        return 0;
     }
 
     int decompress(const unsigned char *src, size_t src_len, unsigned char *dst,
                    size_t dst_len) override {
+
+        /*
+        The code prepared for QAT.
+
+            if (dst_len < src_blk_size) {
+                LOG_ERROR_RETURN(0, -1, "dst_len (`) should be greater than compressed block size `",
+                                dst_len, src_blk_size);
+            }
+            auto ret = LZ4_decompress_qat(pQat, (const char *)src, (char *)dst, src_len, dst_len);
+            if (ret < 0) {
+                LOG_ERROR_RETURN(EFAULT, -1, "LZ4 decompress data failed. (retcode: `)", ret);
+            }
+            if (ret == 0) {
+                LOG_ERROR_RETURN(EFAULT, -1, "LZ4 decompress returns 0. THIS SHOULD BE NEVER HAPPEN!");
+            }
+            LOG_DEBUG("decompressed ` bytes back into ` bytes.", src_len, ret);
+            return ret;
+        */
         if (dst_len < src_blk_size) {
             LOG_ERROR_RETURN(0, -1, "dst_len (`) should be greater than compressed block size `",
                              dst_len, src_blk_size);
@@ -76,146 +183,6 @@ public:
     }
 };
 
-#ifdef ENABLE_QAT
-Compressor_lz4_qat::Compressor_lz4_qat() {
-    max_dst_size = 0;
-    src_blk_size = 0;
-    pQat = new LZ4_qat_param();
-}
-
-Compressor_lz4_qat::~Compressor_lz4_qat() {
-    delete pQat;
-}
-
-int Compressor_lz4_qat::init(const CompressArgs *args) {
-    auto opt = &args->opt;
-    int ret = 0;
-    if (opt == nullptr) {
-        LOG_ERROR_RETURN(EINVAL, -1, "CompressOptions* is nullptr.");
-    };
-    if (opt->type != CompressOptions::LZ4) {
-        LOG_ERROR_RETURN(EINVAL, -1,
-                         "Compression type invalid. (expected: CompressionOptions::LZ4)");
-    }
-    src_blk_size = opt->block_size;
-    max_dst_size = LZ4_compressBound(src_blk_size);
-
-    ret = qat_init(pQat);
-    if (ret != 0) {
-        LOG_ERROR_RETURN(EINVAL, -1, "QAT init fail!");
-    }
-    return 0;
-}
-
-int Compressor_lz4_qat::compress(const unsigned char *src, size_t src_len, unsigned char *dst,
-                                 size_t dst_len) {
-    /*
-    The code prepared for QAT.
-
-        const unsigned char *raw_data[] = {src};
-        size_t steplist[] = {src_len};
-        unsigned char *compressed_data[] = {dst};
-        size_t compressed_len[1];
-
-        if (dst_len < max_dst_size) {
-            LOG_ERROR_RETURN(ENOBUFS, -1, "dst_len should be greater than `", max_dst_size - 1);
-        }
-        auto ret = LZ4_compress_qat(pQat, raw_data, steplist, compressed_data, compressed_len, 0);
-        if (ret < 0) {
-            LOG_ERROR_RETURN(EFAULT, -1, "LZ4 compress data failed. (retcode: `).", ret);
-        }
-        ret = (int)compressed_len[0];
-        return ret;
-    */
-    
-    if (dst_len < max_dst_size) {
-        LOG_ERROR_RETURN(ENOBUFS, -1, "dst_len should be greater than `", max_dst_size - 1);
-    }
-    auto ret = LZ4_compress_default((const char *)src, (char *)dst, src_len, dst_len);
-    if (ret < 0) {
-        LOG_ERROR_RETURN(EFAULT, -1, "LZ4 compress data failed. (retcode: `).", ret);
-    }
-    if (ret == 0) {
-        LOG_ERROR_RETURN(
-            EFAULT, -1,
-            "Compression worked, but was stopped because the *dst couldn't hold all the information.");
-    }
-    return ret;
-}
-
-int Compressor_lz4_qat::compress_batch(const unsigned char *const raw_data[], size_t steplist[],
-                                       unsigned char *compressed_data[], size_t compressed_len[],
-                                       ssize_t cur, size_t dst_len) {
-    /*
-    The code prepared for QAT.
-
-        if (dst_len < max_dst_size) {
-            LOG_ERROR_RETURN(ENOBUFS, -1, "dst_len should be greater than `", max_dst_size - 1);
-        }
-        auto ret = LZ4_compress_qat(pQat, raw_data, steplist, compressed_data, compressed_len, cur);
-        if (ret < 0) {
-            LOG_ERROR_RETURN(EFAULT, -1, "LZ4 compress data failed. (retcode: `).", ret);
-        }
-
-        return ret;
-    */
-
-    if (dst_len < max_dst_size) {
-        LOG_ERROR_RETURN(ENOBUFS, -1, "dst_len should be greater than `", max_dst_size - 1);
-    }
-    int ret;
-    for (ssize_t i = 0; i <= cur; i++) {
-        ret = LZ4_compress_default((const char *)raw_data[i], (char *)compressed_data[i],
-                                   steplist[i], dst_len);
-        compressed_len[i] = ret;
-        if (ret < 0) {
-            LOG_ERROR_RETURN(EFAULT, -1, "LZ4 compress data failed. (retcode: `).", ret);
-        }
-        if (ret == 0) {
-            LOG_ERROR_RETURN(
-                EFAULT, -1,
-                "Compression worked, but was stopped because the *dst couldn't hold all the information.");
-        }
-    }
-    return ret;
-}
-
-int Compressor_lz4_qat::decompress(const unsigned char *src, size_t src_len, unsigned char *dst,
-                                   size_t dst_len) {
-    /*
-    The code prepared for QAT.
-
-        if (dst_len < src_blk_size) {
-            LOG_ERROR_RETURN(0, -1, "dst_len (`) should be greater than compressed block size `",
-                            dst_len, src_blk_size);
-        }
-        auto ret = LZ4_decompress_qat(pQat, (const char *)src, (char *)dst, src_len, dst_len);
-        if (ret < 0) {
-            LOG_ERROR_RETURN(EFAULT, -1, "LZ4 decompress data failed. (retcode: `)", ret);
-        }
-        if (ret == 0) {
-            LOG_ERROR_RETURN(EFAULT, -1, "LZ4 decompress returns 0. THIS SHOULD BE NEVER HAPPEN!");
-        }
-        LOG_DEBUG("decompressed ` bytes back into ` bytes.", src_len, ret);
-        return ret;
-    */
-
-    if (dst_len < src_blk_size) {
-        LOG_ERROR_RETURN(0, -1, "dst_len (`) should be greater than compressed block size `",
-                         dst_len, src_blk_size);
-    }
-    auto ret = LZ4_decompress_safe((const char *)src, (char *)dst, src_len, dst_len);
-    if (ret < 0) {
-        LOG_ERROR_RETURN(EFAULT, -1, "LZ4 decompress data failed. (retcode: `)", ret);
-    }
-    if (ret == 0) {
-        LOG_ERROR_RETURN(EFAULT, -1, "LZ4 decompress returns 0. THIS SHOULD BE NEVER HAPPEN!");
-    }
-    LOG_DEBUG("decompressed ` bytes back into ` bytes.", src_len, ret);
-    return ret;
-}
-#endif
-
 ICompressor *create_compressor(const CompressArgs *args) {
     ICompressor *rst = nullptr;
     int init_flg = 0;
@@ -223,20 +190,11 @@ ICompressor *create_compressor(const CompressArgs *args) {
     switch (opt.type) {
 
     case CompressOptions::LZ4:
-#ifdef ENABLE_QAT
-        rst = new Compressor_lz4_qat;
-        if (rst != nullptr) {
-            init_flg = ((Compressor_lz4_qat *)rst)->init(args);
-        }
-#else
         rst = new Compressor_lz4;
         if (rst != nullptr) {
             init_flg = ((Compressor_lz4 *)rst)->init(args);
         }
-#endif
-
         break;
-
     default:
         LOG_ERROR_RETURN(EINVAL, nullptr, "invalid CompressionOptions.");
     }

--- a/src/overlaybd/fs/zfile/compressor.h
+++ b/src/overlaybd/fs/zfile/compressor.h
@@ -74,6 +74,12 @@ public:
     */
     virtual int compress(const unsigned char *src, size_t src_len, unsigned char *dst,
                          size_t dst_len) = 0;
+
+    // return the number of batches in QAT compressing...
+    virtual int nbatch() = 0;
+    virtual int compress_batch(const unsigned char *src, size_t *src_chunk_len, unsigned char *dst,
+                        size_t dst_buffer_capacity, size_t *dst_chunk_len /* save result chunk length */, 
+                        size_t nchunk) = 0;
     /*
         return decompressed buffer size.
         return -1 when error occurred.
@@ -81,29 +87,6 @@ public:
     virtual int decompress(const unsigned char *src, size_t src_len, unsigned char *dst,
                            size_t dst_len) = 0;
 };
-
-#ifdef ENABLE_QAT
-class Compressor_lz4_qat : public ICompressor {
-public:
-    uint32_t max_dst_size;
-    uint32_t src_blk_size;
-    LZ4_qat_param *pQat;
-
-    Compressor_lz4_qat();
-
-    ~Compressor_lz4_qat();
-
-    int init(const CompressArgs *args);
-
-    int compress(const unsigned char *src, size_t src_len, unsigned char *dst, size_t dst_len);
-
-    int compress_batch(const unsigned char *const raw_data[], size_t steplist[],
-                       unsigned char *compressed_data[], size_t compressed_len[], ssize_t cur,
-                       size_t dst_len);
-
-    int decompress(const unsigned char *src, size_t src_len, unsigned char *dst, size_t dst_len);
-};
-#endif
 
 extern "C" ICompressor *create_compressor(const CompressArgs *args);
 } // namespace ZFile


### PR DESCRIPTION
1. add ICompressor::batch_compress() to support QAT
2. ZFile will use batch compress by default.

Signed-off-by: Yifan Yuan <tuji.yyf@alibaba-inc.com>